### PR TITLE
support or versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,18 @@
 {
   "name": "bomlint",
-  "version": "1.2.5",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "bomlint",
-      "version": "1.2.5",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^10.0.1"
       },
       "bin": {
-        "bomlint": "dist/main.js",
-        "bomlintall": "bin/bomlintall.sh"
+        "bomlint": "bin/main.js"
       },
       "devDependencies": {
         "@types/jest": "^29.5.1",

--- a/src/bomlint.test.ts
+++ b/src/bomlint.test.ts
@@ -118,8 +118,21 @@ describe('bomlint check', function () {
         expect(r.patchedPackageJson?.peerDependencies?.baz).toEqual("Z");
     });
     test('failing dups in same package', function () {
-        const r = checkForUpdatesFromBom(
+        expectSuccess(
             {},
+            {
+                dependencies: {
+                    "foo": "X"
+                },
+                devDependencies: {
+                    "foo": "YY"
+                }
+            }
+        );
+    })
+    test('support or-versions', function () {
+        expectSuccess(
+            {"foo": "X || Y"},
             {
                 dependencies: {
                     "foo": "X"

--- a/src/bomlint.ts
+++ b/src/bomlint.ts
@@ -149,7 +149,18 @@ export function checkForUpdatesFromBom(bom: StringDict, packageJson: IPackageJso
 }
 
 function hasDifferentVersion(deps: any, pkg: string, version: string) {
-    return deps && deps[pkg] && deps[pkg] !== version
+    return deps && deps[pkg] && !acceptVersion(deps[pkg], version)
+}
+
+function acceptVersion(actual: string, expected: string): boolean {
+    return expected === actual || acceptOrVersion(actual, expected);
+}
+
+function acceptOrVersion(actual: string, expected: string): boolean {
+    if (expected.indexOf("||") >= 0) {
+        return expected.split("||").map(v => v.trim()).some(e => e === actual);
+    }
+    return false;
 }
 
 export interface MergeResult {


### PR DESCRIPTION
It can be useful to express an or version in the bomlint.json file, like
```
... "react": "^16.0.0 || ^17.0.0"
```

But have other packages in the workspace that use only one, like a library component with 
```
... "react": "^16.0.0 || ^17.0.0"
```
and like a sandbox with
```
... "react": "^17.0.0"
```

